### PR TITLE
[Bug #154131151] change version of psycopgy2 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ django_compressor==2.1
 djmail==0.11.0
 futures==3.0.3
 premailer==2.9.6
-psycopg2==2.6.1
+psycopg2==2.7.3.1
 requests==2.9.1


### PR DESCRIPTION
## What does this PR do?
Update psycopgy2  from version 2.6.1 to 2.7.3.1

##  Description of Task to be completed?
update the psycopgy2 version in requirements.txt 

## How should this be manually tested?

running the `pip install -r requirements.txt` after the update


##  What are the relevant pivotal tracker stories?

[#154131151](https://www.pivotaltracker.com/story/show/154131151)

## Screenshot

<img width="1121" alt="screen shot 2018-01-08 at 16 12 29" src="https://user-images.githubusercontent.com/10160787/34672436-7b08ad7a-f48f-11e7-892b-0495d353a757.png">
