### PR TITLE
#153728035 Add time periods and grace periods running more than 30 days

### DIFF
--- a/hc/api/schemas.py
+++ b/hc/api/schemas.py
@@ -2,8 +2,8 @@ check = {
     "properties": {
         "name": {"type": "string"},
         "tags": {"type": "string"},
-        "timeout": {"type": "number", "minimum": 60, "maximum": 604800},
-        "grace": {"type": "number", "minimum": 60, "maximum": 604800},
+        "timeout": {"type": "number", "minimum": 60, "maximum": 5184000},
+        "grace": {"type": "number", "minimum": 60, "maximum": 5184000},
         "channels": {"type": "string"}
     }
 }

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -18,8 +18,8 @@ class NameTagsForm(forms.Form):
 
 
 class TimeoutForm(forms.Form):
-    timeout = forms.IntegerField(min_value=60, max_value=2592000)
-    grace = forms.IntegerField(min_value=60, max_value=2592000)
+    timeout = forms.IntegerField(min_value=60, max_value=5184000)
+    grace = forms.IntegerField(min_value=60, max_value=5184000)
 
 
 class AddChannelForm(forms.ModelForm):

--- a/hc/front/tests/test_period_update_check.py
+++ b/hc/front/tests/test_period_update_check.py
@@ -1,0 +1,22 @@
+from hc.api.models import Check
+from hc.test import BaseTestCase
+
+
+class PeriodTimeoutTestcase(BaseTestCase):
+
+    def setUp(self):
+        super(PeriodTimeoutTestcase, self).setUp()
+        self.check = Check(user=self.alice)
+        self.check.save()
+
+    def test_timeout_over_one_month(self):
+        url = "/checks/%s/timeout/" % self.check.code
+        payload = {"timeout": 5184000, "grace": 5100000}
+
+        self.client.login(username="alice@example.org", password="password")
+        r = self.client.post(url, data=payload)
+        self.assertRedirects(r, "/checks/")
+
+        check = Check.objects.get(code=self.check.code)
+        assert check.timeout.total_seconds() == 5184000
+        assert check.grace.total_seconds() == 5100000

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -4,7 +4,8 @@ $(function () {
     var HOUR = {name: "hour", nsecs: MINUTE.nsecs * 60};
     var DAY = {name: "day", nsecs: HOUR.nsecs * 24};
     var WEEK = {name: "week", nsecs: DAY.nsecs * 7};
-    var UNITS = [WEEK, DAY, HOUR, MINUTE];
+    var MONTH = { name: "month", nsecs: (WEEK.nsecs * 4 + (HOUR.nsecs * 24 * 2)) };
+    var UNITS = [MONTH, WEEK, DAY, HOUR, MINUTE];
 
     var secsToText = function(total) {
         var remainingSeconds = Math.floor(total);
@@ -39,12 +40,12 @@ $(function () {
             '33%': [3600, 3600],
             '66%': [86400, 86400],
             '83%': [604800, 604800],
-            'max': 2592000,
+            'max': 5184000,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
-            density: 4,
+            values: [60, 1800, 3600, 43200, 86400, 604800, 5184000],
+            density: 5,
             format: {
                 to: secsToText,
                 from: function() {}
@@ -68,11 +69,11 @@ $(function () {
             '33%': [3600, 3600],
             '66%': [86400, 86400],
             '83%': [604800, 604800],
-            'max': 2592000,
+            'max': 5184000,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 1800, 3600, 43200, 86400, 604800, 5184000],
             density: 4,
             format: {
                 to: secsToText,


### PR DESCRIPTION
#### What does this PR do?

Ensures that user can set periods and grace times of more than 30 days
Test the functionality

#### Description of Task to be completed?
Create a test to check if user is able to set periods of more than 30 days 
Adjust the module to ensure that user can be able to set periods that exceed 30 days
Create a variable that accommodates months in the check slider

#### How should this be manually tested?
Open health checks.io on your localhost 
Create a check and navigate to the check 
One should be able to set periods that exceed 30 days

#### Any background context you want to provide?
The files changed/created include:
forms.py in `hc/front/forms.py` to accommodate for the maximum number of seconds that the app should allow
schemas.py in `hc/api/schemas.py` to change the maximum seconds in the API module 
[new]test_period_update_check.py in `hc/front/tests/test_period_update_check.py` to test for checks that exceed a period of 30 days
checks.js in `static/js/checks.js` to create the month module and slider parameters in the front end

#### What are the relevant pivotal tracker stories?

[#153728035](https://www.pivotaltracker.com/story/show/153728035)
#### Screenshots (if appropriate)


<img width="1440" alt="screen shot 2018-01-17 at 06 28 07" src="https://user-images.githubusercontent.com/10160787/35024283-a3fa281e-fb4f-11e7-8f7a-2f0feb361ddc.png">
